### PR TITLE
swirl: fix escript support

### DIFF
--- a/src/swirl.erl
+++ b/src/swirl.erl
@@ -227,7 +227,6 @@ help() ->
 %% for escript support
 -spec main(any()) -> no_return().
 main(_) ->
-    help(),
-    start(),
-    _ = start_peer(),
+    ok = start(),
+    {ok, _ } = start_peer(),
     timer:sleep(infinity).


### PR DESCRIPTION
- broken in 9f0df1b
- closes #40
- thanks @kxepal for finding this one